### PR TITLE
Add NEON path for sparse intersections

### DIFF
--- a/src/core/entangled.rs
+++ b/src/core/entangled.rs
@@ -236,11 +236,9 @@ impl EntangledHVec {
         Self { dim, indices }
     }
 
-    /// Hamming distance via sorted-merge intersection count on sparse index sets.
+    /// Hamming distance via the adaptive sparse distance kernel.
     pub fn hamming(&self, other: &Self) -> u32 {
-        let intersection =
-            super::intersection::sparse_intersection_count(&self.indices, &other.indices);
-        (self.indices.len() + other.indices.len() - 2 * intersection) as u32
+        super::intersection::sparse_hamming_distance(&self.indices, &other.indices)
     }
 
     /// Jaccard similarity: |A∩B| / |A∪B|.

--- a/src/core/intersection.rs
+++ b/src/core/intersection.rs
@@ -44,6 +44,12 @@ fn merge_intersection_count(a: &[u32], b: &[u32]) -> usize {
         }
     }
 
+    #[cfg(target_arch = "aarch64")]
+    {
+        // NEON is part of the baseline aarch64 target.
+        return unsafe { merge_intersection_count_neon(a, b) };
+    }
+
     merge_intersection_count_scalar(a, b)
 }
 
@@ -66,10 +72,15 @@ fn merge_intersection_count_scalar(a: &[u32], b: &[u32]) -> usize {
     count
 }
 
+#[cfg(target_arch = "x86")]
+use std::arch::x86 as x86_simd;
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64 as x86_simd;
+
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2")]
 unsafe fn merge_intersection_count_avx2(a: &[u32], b: &[u32]) -> usize {
-    use std::arch::x86_64::{
+    use x86_simd::{
         __m256i, _mm256_castsi256_ps, _mm256_cmpeq_epi32, _mm256_loadu_si256,
         _mm256_movemask_ps, _mm256_set1_epi32,
     };
@@ -104,6 +115,54 @@ unsafe fn merge_intersection_count_avx2(a: &[u32], b: &[u32]) -> usize {
                 j += offset + 1;
             } else if b[j + 7] < av {
                 j += 8;
+            } else {
+                j += 1;
+            }
+        } else {
+            j += 1;
+        }
+    }
+
+    count
+}
+
+#[cfg(target_arch = "aarch64")]
+unsafe fn merge_intersection_count_neon(a: &[u32], b: &[u32]) -> usize {
+    use std::arch::aarch64::{
+        uint32x4_t, vceqq_u32, vdupq_n_u32, vld1q_u32, vmaxvq_u32,
+    };
+
+    let mut count = 0;
+    let mut i = 0;
+    let mut j = 0;
+
+    while i < a.len() && j < b.len() {
+        let av = a[i];
+        let bv = b[j];
+
+        if av == bv {
+            count += 1;
+            i += 1;
+            j += 1;
+        } else if av < bv {
+            if i + 4 <= a.len() && a[i + 3] < bv {
+                i += 4;
+            } else {
+                i += 1;
+            }
+        } else if j + 4 <= b.len() {
+            let needle = vdupq_n_u32(av);
+            let chunk = vld1q_u32(b[j..].as_ptr() as *const u32);
+            let eq: uint32x4_t = vceqq_u32(needle, chunk);
+            if vmaxvq_u32(eq) != 0 {
+                count += 1;
+                while b[j] != av {
+                    j += 1;
+                }
+                i += 1;
+                j += 1;
+            } else if b[j + 3] < av {
+                j += 4;
             } else {
                 j += 1;
             }
@@ -168,6 +227,7 @@ mod tests {
         let a = vec![1, 3, 5, 7, 9];
         let b = vec![2, 3, 6, 7, 10];
         assert_eq!(sparse_intersection_count(&a, &b), 2);
+        assert_eq!(sparse_hamming_distance(&a, &b), 6);
     }
 
     #[test]

--- a/src/core/intersection.rs
+++ b/src/core/intersection.rs
@@ -1,13 +1,24 @@
 //! Sparse intersection primitives.
 //!
-//! Galloping intersection for skewed sizes, sorted merge for balanced.
+//! Galloping intersection for skewed sizes, SIMD-assisted sorted merge for balanced.
+
+/// Hamming distance between two sorted sparse bit-index slices.
+///
+/// Uses the adaptive intersection kernel underneath, so callers get the best
+/// available path without duplicating the symmetric-difference arithmetic.
+#[inline]
+pub fn sparse_hamming_distance(a: &[u32], b: &[u32]) -> u32 {
+    let intersection = sparse_intersection_count(a, b);
+    (a.len() + b.len() - 2 * intersection) as u32
+}
 
 /// Count common elements in two sorted u32 slices.
 ///
 /// Adaptively picks the best algorithm:
 /// - When one slice is much smaller (|a| * 8 < |b|), uses galloping search
 ///   which is O(|small| * log(|large|)) and beats O(|a| + |b|) merge.
-/// - Otherwise uses the standard sorted merge at O(|a| + |b|).
+/// - Otherwise uses a sorted merge at O(|a| + |b|), with runtime SIMD
+///   dispatch on x86/x86_64 when AVX2 is available.
 #[inline]
 pub fn sparse_intersection_count(a: &[u32], b: &[u32]) -> usize {
     if a.is_empty() || b.is_empty() {
@@ -25,6 +36,19 @@ pub fn sparse_intersection_count(a: &[u32], b: &[u32]) -> usize {
 /// Sorted merge intersection count: O(|a| + |b|).
 #[inline]
 fn merge_intersection_count(a: &[u32], b: &[u32]) -> usize {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        if std::arch::is_x86_feature_detected!("avx2") {
+            // SAFETY: guarded by runtime AVX2 feature detection above.
+            return unsafe { merge_intersection_count_avx2(a, b) };
+        }
+    }
+
+    merge_intersection_count_scalar(a, b)
+}
+
+#[inline]
+fn merge_intersection_count_scalar(a: &[u32], b: &[u32]) -> usize {
     let mut count = 0;
     let mut i = 0;
     let mut j = 0;
@@ -39,6 +63,55 @@ fn merge_intersection_count(a: &[u32], b: &[u32]) -> usize {
             }
         }
     }
+    count
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx2")]
+unsafe fn merge_intersection_count_avx2(a: &[u32], b: &[u32]) -> usize {
+    use std::arch::x86_64::{
+        __m256i, _mm256_castsi256_ps, _mm256_cmpeq_epi32, _mm256_loadu_si256,
+        _mm256_movemask_ps, _mm256_set1_epi32,
+    };
+
+    let mut count = 0;
+    let mut i = 0;
+    let mut j = 0;
+
+    while i < a.len() && j < b.len() {
+        let av = a[i];
+        let bv = b[j];
+
+        if av == bv {
+            count += 1;
+            i += 1;
+            j += 1;
+        } else if av < bv {
+            if i + 8 <= a.len() && a[i + 7] < bv {
+                i += 8;
+            } else {
+                i += 1;
+            }
+        } else if j + 8 <= b.len() {
+            let needle = _mm256_set1_epi32(av as i32);
+            let chunk = _mm256_loadu_si256(b[j..].as_ptr() as *const __m256i);
+            let eq = _mm256_cmpeq_epi32(needle, chunk);
+            let mask = _mm256_movemask_ps(_mm256_castsi256_ps(eq));
+            if mask != 0 {
+                count += 1;
+                let offset = mask.trailing_zeros() as usize;
+                i += 1;
+                j += offset + 1;
+            } else if b[j + 7] < av {
+                j += 8;
+            } else {
+                j += 1;
+            }
+        } else {
+            j += 1;
+        }
+    }
+
     count
 }
 
@@ -132,6 +205,13 @@ mod tests {
         let b: Vec<u32> = (0..100).step_by(3).collect(); // multiples of 3
         let expected = (0..100u32).filter(|x| x % 2 == 0 && x % 3 == 0).count();
         assert_eq!(sparse_intersection_count(&a, &b), expected);
+        assert_eq!(merge_intersection_count_scalar(&a, &b), expected);
+
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        if std::arch::is_x86_feature_detected!("avx2") {
+            // SAFETY: guarded by runtime AVX2 feature detection above.
+            assert_eq!(unsafe { merge_intersection_count_avx2(&a, &b) }, expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Adds a small NEON-backed intersection path for aarch64 while keeping the existing AVX2 runtime dispatch on x86 and the scalar fallback elsewhere. The Hamming distance helper now has an explicit unit assertion so the symmetric-difference calculation remains covered alongside the intersection count. I could not run the Rust test suite in this environment because cargo is not installed, but the change is limited to the sparse intersection kernel and keeps existing public behavior intact.