### PR TITLE
deps: land 10 Dependabot major bumps with API fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,23 +17,23 @@ readme = "README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-napi = { version = "2.14", features = ["async", "serde-json"], optional = true }
-napi-derive = { version = "2.14", optional = true }
+napi = { version = "3.9", features = ["async", "serde-json"], optional = true }
+napi-derive = { version = "3.5", optional = true }
 pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"], optional = true }
 tokio = { version = "1", features = ["full"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
-ts-rs = { version = "10", features = ["serde-compat"] }
-schemars = { version = "0.8", features = ["derive"] }
+ts-rs = { version = "12", features = ["serde-compat"] }
+schemars = { version = "1.2", features = ["derive"] }
 serde_json = "1.0"
-bincode = "1.3"
-rand = "0.8"
+bincode = { version = "2.0", features = ["serde"] }
+rand = "0.10"
 crc32fast = "1.3"
-lz4_flex = "0.11"
+lz4_flex = "0.13"
 rayon = "1.8"
 parking_lot = "0.12"
 memmap2 = "0.9"
 anyhow = "1.0"
-thiserror = "1.0"
+thiserror = "2.0"
 tracing = "0.1"
 clap = { version = "4.4", features = ["derive"] }
 fxhash = "0.2"
@@ -42,7 +42,7 @@ ed25519-dalek = { version = "2", features = ["rand_core"], optional = true }
 zeroize = { version = "1", features = ["derive"], optional = true }
 aes-gcm = { version = "0.10", optional = true }
 argon2 = { version = "0.5", optional = true }
-sha2 = { version = "0.10", optional = true }
+sha2 = { version = "0.11", optional = true }
 coset = { version = "0.4", optional = true }
 ciborium = { version = "0.2", optional = true }
 bs58 = { version = "0.5", optional = true }
@@ -52,10 +52,10 @@ base64 = { version = "0.22", optional = true }
 tempfile = "3"
 
 [build-dependencies]
-napi-build = { version = "2.0", optional = true }
+napi-build = { version = "2.2", optional = true }
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = "0.8"
 proptest = "1.0"
 tempfile = "3"
 

--- a/benches/hms_benchmark.rs
+++ b/benches/hms_benchmark.rs
@@ -1,5 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use holographic_memory::{EntangledHVec, HmsCore};
+use std::hint::black_box;
 
 fn benchmark_entangled(c: &mut Criterion) {
     let dim = 16384;

--- a/deny.toml
+++ b/deny.toml
@@ -25,6 +25,7 @@ allow = [
     "Unicode-3.0",
     "Zlib",
     "CDLA-Permissive-2.0",
+    "Apache-2.0 WITH LLVM-exception",
 ]
 
 [bans]

--- a/deny.toml
+++ b/deny.toml
@@ -6,11 +6,12 @@ yanked = "warn"
 
 # Ignore advisories for unmaintained crates that have no safe upgrade path.
 # TODO: migrate fxhash -> rustc-hash (RUSTSEC-2025-0057)
-# TODO: migrate bincode 1.x -> bitcode or postcard (RUSTSEC-2025-0141)
+# bincode is unmaintained at every version (team ceased development); 2.x is the
+# latest release and there is no maintained successor (RUSTSEC-2025-0141).
 # TODO: paste comes from nalgebra/simba; upgrade path blocked on upstream (RUSTSEC-2024-0436)
 ignore = [
     { id = "RUSTSEC-2025-0057", reason = "fxhash has no safe upgrade; planned migration to rustc-hash" },
-    { id = "RUSTSEC-2025-0141", reason = "bincode 1.x has no compatible upgrade; planned migration to bitcode" },
+    { id = "RUSTSEC-2025-0141", reason = "bincode is unmaintained at all versions; on latest 2.x, no maintained successor" },
     { id = "RUSTSEC-2024-0436", reason = "paste is a transitive dep via nalgebra/simba; no upstream fix available" },
 ]
 

--- a/package.json
+++ b/package.json
@@ -28,28 +28,28 @@
   "main": "index.js",
   "types": "index.d.ts",
   "napi": {
-    "name": "holographic-memory",
-    "triples": {
-      "defaults": true,
-      "additional": [
-        "aarch64-apple-darwin"
-      ]
-    }
+    "binaryName": "holographic-memory",
+    "targets": [
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-unknown-linux-gnu",
+      "x86_64-pc-windows-msvc"
+    ]
   },
   "scripts": {
-    "build": "napi build --release",
-    "build:debug": "napi build",
+    "build": "napi build --release --features node-api",
+    "build:debug": "napi build --features node-api",
     "prepublishOnly": "napi prepublish -t npm",
     "artifacts": "napi artifacts",
     "version": "napi version"
   },
   "devDependencies": {
-    "@napi-rs/cli": "^2.17.0"
+    "@napi-rs/cli": "^3.7.4"
   },
   "optionalDependencies": {
-    "holographic-memory-win32-x64-msvc": "0.6.0",
+    "holographic-memory-darwin-arm64": "0.6.0",
     "holographic-memory-darwin-x64": "0.6.0",
     "holographic-memory-linux-x64-gnu": "0.6.0",
-    "holographic-memory-darwin-arm64": "0.6.0"
+    "holographic-memory-win32-x64-msvc": "0.6.0"
   }
 }

--- a/schemas/ConceptCandidate.json
+++ b/schemas/ConceptCandidate.json
@@ -1,14 +1,7 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ConceptCandidate",
   "type": "object",
-  "required": [
-    "centroidId",
-    "coherence",
-    "memberCount",
-    "memberIds",
-    "stable"
-  ],
   "properties": {
     "centroidId": {
       "type": "string"
@@ -20,7 +13,7 @@
     "memberCount": {
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "memberIds": {
       "type": "array",
@@ -32,5 +25,12 @@
       "description": "Whether centroid refinement converged (zero reassignments in last pass).",
       "type": "boolean"
     }
-  }
+  },
+  "required": [
+    "centroidId",
+    "memberCount",
+    "coherence",
+    "memberIds",
+    "stable"
+  ]
 }

--- a/schemas/HmsError.json
+++ b/schemas/HmsError.json
@@ -1,176 +1,156 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "HmsError",
   "oneOf": [
     {
       "type": "object",
-      "required": [
-        "message",
-        "type"
-      ],
       "properties": {
         "message": {
           "type": "object",
-          "required": [
-            "details"
-          ],
           "properties": {
             "details": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "details"
+          ]
         },
         "type": {
           "type": "string",
-          "enum": [
-            "InvalidParam"
-          ]
+          "const": "InvalidParam"
         }
-      }
+      },
+      "required": [
+        "type",
+        "message"
+      ]
     },
     {
       "type": "object",
-      "required": [
-        "message",
-        "type"
-      ],
       "properties": {
         "message": {
           "type": "object",
-          "required": [
-            "context"
-          ],
           "properties": {
             "context": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "context"
+          ]
         },
         "type": {
           "type": "string",
-          "enum": [
-            "StorageFailure"
-          ]
+          "const": "StorageFailure"
         }
-      }
+      },
+      "required": [
+        "type",
+        "message"
+      ]
     },
     {
       "type": "object",
-      "required": [
-        "message",
-        "type"
-      ],
       "properties": {
         "message": {
           "type": "object",
-          "required": [
-            "context"
-          ],
           "properties": {
             "context": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "context"
+          ]
         },
         "type": {
           "type": "string",
-          "enum": [
-            "EncodingFailure"
-          ]
+          "const": "EncodingFailure"
         }
-      }
+      },
+      "required": [
+        "type",
+        "message"
+      ]
     },
     {
       "type": "object",
-      "required": [
-        "message",
-        "type"
-      ],
       "properties": {
         "message": {
           "type": "object",
-          "required": [
-            "context"
-          ],
           "properties": {
             "context": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "context"
+          ]
         },
         "type": {
           "type": "string",
-          "enum": [
-            "QueryFailure"
-          ]
+          "const": "QueryFailure"
         }
-      }
+      },
+      "required": [
+        "type",
+        "message"
+      ]
     },
     {
       "type": "object",
-      "required": [
-        "message",
-        "type"
-      ],
       "properties": {
         "message": {
           "type": "object",
-          "required": [
-            "index_type"
-          ],
           "properties": {
             "index_type": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "index_type"
+          ]
         },
         "type": {
           "type": "string",
-          "enum": [
-            "IndexNotTrained"
-          ]
+          "const": "IndexNotTrained"
         }
-      }
+      },
+      "required": [
+        "type",
+        "message"
+      ]
     },
     {
       "type": "object",
-      "required": [
-        "message",
-        "type"
-      ],
       "properties": {
         "message": {
           "type": "object",
-          "required": [
-            "limit"
-          ],
           "properties": {
             "limit": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "limit"
+          ]
         },
         "type": {
           "type": "string",
-          "enum": [
-            "CapacityExceeded"
-          ]
+          "const": "CapacityExceeded"
         }
-      }
+      },
+      "required": [
+        "type",
+        "message"
+      ]
     },
     {
       "type": "object",
-      "required": [
-        "message",
-        "type"
-      ],
       "properties": {
         "message": {
           "type": "object",
-          "required": [
-            "code",
-            "context"
-          ],
           "properties": {
             "code": {
               "type": "integer",
@@ -179,15 +159,21 @@
             "context": {
               "type": "string"
             }
-          }
+          },
+          "required": [
+            "code",
+            "context"
+          ]
         },
         "type": {
           "type": "string",
-          "enum": [
-            "Internal"
-          ]
+          "const": "Internal"
         }
-      }
+      },
+      "required": [
+        "type",
+        "message"
+      ]
     }
   ]
 }

--- a/schemas/MemorizeBatchItem.json
+++ b/schemas/MemorizeBatchItem.json
@@ -1,12 +1,8 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "MemorizeBatchItem",
   "description": "Input item for batch memorization — a single id/text pair.",
   "type": "object",
-  "required": [
-    "id",
-    "text"
-  ],
   "properties": {
     "id": {
       "type": "string"
@@ -14,5 +10,9 @@
     "text": {
       "type": "string"
     }
-  }
+  },
+  "required": [
+    "id",
+    "text"
+  ]
 }

--- a/schemas/RetrievalResult.json
+++ b/schemas/RetrievalResult.json
@@ -1,11 +1,7 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "RetrievalResult",
   "type": "object",
-  "required": [
-    "id",
-    "similarity"
-  ],
   "properties": {
     "id": {
       "type": "string"
@@ -14,5 +10,9 @@
       "type": "number",
       "format": "double"
     }
-  }
+  },
+  "required": [
+    "id",
+    "similarity"
+  ]
 }

--- a/schemas/TextMetrics.json
+++ b/schemas/TextMetrics.json
@@ -1,45 +1,45 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "TextMetrics",
   "type": "object",
-  "required": [
-    "consonantCount",
-    "punctuationCount",
-    "sentenceCount",
-    "syllableCount",
-    "vowelCount",
-    "wordCount"
-  ],
   "properties": {
     "consonantCount": {
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "punctuationCount": {
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "sentenceCount": {
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "syllableCount": {
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "vowelCount": {
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     },
     "wordCount": {
       "type": "integer",
       "format": "uint32",
-      "minimum": 0.0
+      "minimum": 0
     }
-  }
+  },
+  "required": [
+    "wordCount",
+    "sentenceCount",
+    "syllableCount",
+    "vowelCount",
+    "consonantCount",
+    "punctuationCount"
+  ]
 }

--- a/src/core/connection_graph.rs
+++ b/src/core/connection_graph.rs
@@ -352,7 +352,7 @@ fn chain_step(prev: u64, ev: &Event) -> u64 {
 
 /// Append one length-framed, bincode-encoded event to the durable log.
 fn append_event(writer: &mut BufWriter<File>, ev: &Event) -> std::io::Result<()> {
-    let bytes = bincode::serialize(ev)
+    let bytes = bincode::serde::encode_to_vec(ev, bincode::config::standard())
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     writer.write_all(&(bytes.len() as u32).to_le_bytes())?;
     writer.write_all(&bytes)?;
@@ -373,8 +373,11 @@ fn read_events(path: &Path) -> std::io::Result<Vec<Event>> {
         if off + len > buf.len() {
             break; // truncated tail from an interrupted append
         }
-        match bincode::deserialize::<Event>(&buf[off..off + len]) {
-            Ok(ev) => events.push(ev),
+        match bincode::serde::decode_from_slice::<Event, _>(
+            &buf[off..off + len],
+            bincode::config::standard(),
+        ) {
+            Ok((ev, _)) => events.push(ev),
             Err(_) => break, // corrupt record: stop at last good event
         }
         off += len;

--- a/src/core/diffusion.rs
+++ b/src/core/diffusion.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fxhash::FxHashMap;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 
 use crate::core::config::DiffusionConfig;
 use crate::core::entangled::{EntangledHVec, DEFAULT_RHO_DENOM};
@@ -216,8 +216,8 @@ impl<'a> DiffusionFactorizer<'a> {
 /// Gaussian sample via Box-Muller transform using a seeded PRNG.
 /// Langevin dynamics requires Gaussian noise for the correct stationary distribution.
 fn gaussian_sample(rng: &mut rand::rngs::StdRng) -> f64 {
-    let u1: f64 = rng.gen_range(1e-10..1.0);
-    let u2: f64 = rng.gen::<f64>();
+    let u1: f64 = rng.random_range(1e-10..1.0);
+    let u2: f64 = rng.random::<f64>();
     (-2.0 * u1.ln()).sqrt() * (2.0 * std::f64::consts::PI * u2).cos()
 }
 

--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -279,7 +279,8 @@ impl HmsCore {
             if nsg_path.exists() {
                 let raw = std::fs::read(&nsg_path)?;
                 let data = self.maybe_decrypt(&raw)?;
-                let nsg: super::nsg::NSGIndex = bincode::deserialize(&data)?;
+                let (nsg, _): (super::nsg::NSGIndex, usize) =
+                    bincode::serde::decode_from_slice(&data, bincode::config::standard())?;
                 *shard.nsg.write() = Some(nsg);
             }
 
@@ -287,7 +288,8 @@ impl HmsCore {
             if ivf_path.exists() {
                 let raw = std::fs::read(&ivf_path)?;
                 let data = self.maybe_decrypt(&raw)?;
-                let mut ivf: IVFIndex = bincode::deserialize(&data)?;
+                let (mut ivf, _): (IVFIndex, usize) =
+                    bincode::serde::decode_from_slice(&data, bincode::config::standard())?;
                 ivf.lists = Some(super::ivf::inverted_list::InvertedLists::new());
 
                 let vectors = shard.vectors.read();
@@ -310,11 +312,11 @@ impl HmsCore {
         let multi = shards.shard_count() > 1;
         shards.try_for_each_shard_indexed(|i, shard| {
             if let Some(ref nsg) = *shard.nsg.read() {
-                let data = bincode::serialize(nsg)?;
+                let data = bincode::serde::encode_to_vec(nsg, bincode::config::standard())?;
                 std::fs::write(self.nsg_index_path(i, multi), self.maybe_encrypt(&data)?)?;
             }
             if let Some(ref ivf) = *shard.ivf.read() {
-                let data = bincode::serialize(ivf)?;
+                let data = bincode::serde::encode_to_vec(ivf, bincode::config::standard())?;
                 std::fs::write(self.ivf_index_path(i, multi), self.maybe_encrypt(&data)?)?;
             }
             Ok(())

--- a/src/core/entangled.rs
+++ b/src/core/entangled.rs
@@ -505,7 +505,7 @@ impl EntangledHVec {
         let mut current = all_indices[0];
         let mut count: u32 = 1;
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         for &idx in &all_indices[1..] {
             if idx == current {
@@ -546,8 +546,8 @@ impl EntangledHVec {
 }
 
 /// Sample from Laplace(0, scale) using inverse CDF.
-fn laplace_sample(rng: &mut impl rand::Rng, scale: f64) -> f64 {
-    let u: f64 = rng.gen::<f64>() - 0.5;
+fn laplace_sample(rng: &mut impl rand::RngExt, scale: f64) -> f64 {
+    let u: f64 = rng.random::<f64>() - 0.5;
     -scale * u.signum() * (1.0 - 2.0 * u.abs()).ln()
 }
 

--- a/src/core/indexed_memory.rs
+++ b/src/core/indexed_memory.rs
@@ -299,10 +299,10 @@ mod tests {
         let indices = original.indices().to_vec();
         let mut noisy = indices.clone();
         // Flip 25% of active indices (16 of 64)
-        let mut rng = rand::thread_rng();
-        use rand::Rng;
+        let mut rng = rand::rng();
+        use rand::RngExt;
         for item in noisy.iter_mut().take(16) {
-            *item = rng.gen_range(0..16384u32);
+            *item = rng.random_range(0..16384u32);
         }
         noisy.sort_unstable();
         noisy.dedup();

--- a/src/core/ivf/kmeans.rs
+++ b/src/core/ivf/kmeans.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use nalgebra::DVector;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt, SeedableRng};
 use serde::{Deserialize, Serialize};
 
 const MAX_ITERS: usize = 50;
@@ -117,7 +117,7 @@ fn kmeans_plus_plus_init(data: &[DVector<f32>], k: usize, seed: u64) -> Vec<DVec
     }
 
     let mut centroids = Vec::with_capacity(k);
-    centroids.push(data[rng.gen_range(0..n)].clone());
+    centroids.push(data[rng.random_range(0..n)].clone());
 
     let mut dists = vec![f32::MAX; n];
 
@@ -132,11 +132,11 @@ fn kmeans_plus_plus_init(data: &[DVector<f32>], k: usize, seed: u64) -> Vec<DVec
 
         let total: f64 = dists.iter().map(|&d| d as f64).sum();
         if total < 1e-12 {
-            centroids.push(data[rng.gen_range(0..n)].clone());
+            centroids.push(data[rng.random_range(0..n)].clone());
             continue;
         }
 
-        let threshold = rng.gen::<f64>() * total;
+        let threshold = rng.random::<f64>() * total;
         let mut cumulative = 0.0;
         let mut chosen = 0;
         for (i, &d) in dists.iter().enumerate() {
@@ -166,7 +166,7 @@ mod tests {
             DVector::from_vec(vec![0.0, 0.0, 10.0, 10.0]),
         ] {
             for _ in 0..50 {
-                let noise = DVector::from_fn(4, |_, _| rng.gen::<f32>() * 0.5);
+                let noise = DVector::from_fn(4, |_, _| rng.random::<f32>() * 0.5);
                 data.push(center + noise);
             }
         }

--- a/src/core/nsg/graph.rs
+++ b/src/core/nsg/graph.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use rand::Rng;
+use rand::RngExt;
 use rayon::prelude::*;
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -36,7 +36,7 @@ pub(super) fn build_knn_graph(
         .map(|i| {
             let mut neighbors = HashSet::with_capacity(k);
             while neighbors.len() < k {
-                let j = rng.gen_range(0..n);
+                let j = rng.random_range(0..n);
                 if j != i {
                     neighbors.insert(j as u32);
                 }

--- a/src/core/phase_resonator.rs
+++ b/src/core/phase_resonator.rs
@@ -409,9 +409,7 @@ mod tests {
         let mut ok = 0;
         let trials = 20;
         for t in 0..trials {
-            let idx: Vec<usize> = (0..3)
-                .map(|axis| ((t * 7 + axis * 3) % f) as usize)
-                .collect();
+            let idx: Vec<usize> = (0..3).map(|axis| (t * 7 + axis * 3) % f).collect();
             let res = phase_resonator_factorize(&compose(&cbs, &idx), &cbs, &cfg);
             if (0..3).all(|a| res[a].codebook_entry == idx[a]) {
                 ok += 1;

--- a/src/core/provenance/c2pa_manifest.rs
+++ b/src/core/provenance/c2pa_manifest.rs
@@ -389,7 +389,7 @@ mod tests {
     use super::*;
 
     fn test_keypair() -> SigningKey {
-        SigningKey::generate(&mut rand::thread_rng())
+        SigningKey::from_bytes(&rand::random())
     }
 
     #[test]

--- a/src/core/provenance/cawg.rs
+++ b/src/core/provenance/cawg.rs
@@ -289,7 +289,7 @@ mod tests {
     use super::*;
 
     fn test_keypair() -> SigningKey {
-        SigningKey::generate(&mut rand::thread_rng())
+        SigningKey::from_bytes(&rand::random())
     }
 
     fn ica_refs() -> Vec<(String, String, Vec<u8>)> {

--- a/src/core/provenance/cose.rs
+++ b/src/core/provenance/cose.rs
@@ -101,7 +101,7 @@ mod tests {
     use super::*;
 
     fn test_keypair() -> SigningKey {
-        SigningKey::generate(&mut rand::thread_rng())
+        SigningKey::from_bytes(&rand::random())
     }
 
     #[test]

--- a/src/core/provenance/keri.rs
+++ b/src/core/provenance/keri.rs
@@ -343,7 +343,7 @@ mod tests {
     use super::*;
 
     fn test_keypair() -> SigningKey {
-        SigningKey::generate(&mut rand::thread_rng())
+        SigningKey::from_bytes(&rand::random())
     }
 
     fn next_key_digest(key: &SigningKey) -> String {

--- a/src/core/provenance/mod.rs
+++ b/src/core/provenance/mod.rs
@@ -1345,7 +1345,7 @@ mod tests {
         // The record's signature is internally valid, but a trust store that
         // does not contain the signing key must reject it as non-authentic,
         // even though every signature check passes.
-        let stranger = SigningKey::generate(&mut rand::thread_rng());
+        let stranger = SigningKey::from_bytes(&rand::random());
         let foreign_trust = trust::TrustStore::trusting_key(&stranger.verifying_key());
         let rejected = mgr.verify_fact_provenance(&record, &foreign_trust).unwrap();
         assert!(!rejected.valid);
@@ -1382,7 +1382,7 @@ mod tests {
             .iter()
             .any(|d| d.check == "trust_anchor" && d.passed));
 
-        let stranger = SigningKey::generate(&mut rand::thread_rng());
+        let stranger = SigningKey::from_bytes(&rand::random());
         let foreign = trust::TrustStore::trusting_key(&stranger.verifying_key());
         let rejected = verify_record(&vc_only, &foreign).unwrap();
         assert!(!rejected.valid);
@@ -1411,7 +1411,7 @@ mod tests {
 
         // A trust store that does not contain the issuer must reject it, even
         // though the assertion is internally self-consistent.
-        let stranger = SigningKey::generate(&mut rand::thread_rng());
+        let stranger = SigningKey::from_bytes(&rand::random());
         let foreign = trust::TrustStore::trusting_key(&stranger.verifying_key());
         assert!(mgr.verify_cawg_assertion(&assertion, &foreign).is_err());
     }

--- a/src/core/provenance/scitt.rs
+++ b/src/core/provenance/scitt.rs
@@ -259,7 +259,7 @@ mod tests {
     use super::*;
 
     fn test_keypair() -> SigningKey {
-        SigningKey::generate(&mut rand::thread_rng())
+        SigningKey::from_bytes(&rand::random())
     }
 
     #[test]

--- a/src/core/provenance/sigstore.rs
+++ b/src/core/provenance/sigstore.rs
@@ -212,7 +212,7 @@ mod tests {
     use super::*;
 
     fn test_keypair() -> SigningKey {
-        SigningKey::generate(&mut rand::thread_rng())
+        SigningKey::from_bytes(&rand::random())
     }
 
     #[test]

--- a/src/core/provenance/trust.rs
+++ b/src/core/provenance/trust.rs
@@ -92,7 +92,7 @@ mod tests {
     use ed25519_dalek::SigningKey;
 
     fn key() -> SigningKey {
-        SigningKey::generate(&mut rand::thread_rng())
+        SigningKey::from_bytes(&rand::random())
     }
 
     #[test]

--- a/src/core/provenance/vc.rs
+++ b/src/core/provenance/vc.rs
@@ -263,9 +263,9 @@ fn days_to_ymd(days_since_epoch: u64) -> (u64, u64, u64) {
 }
 
 fn simple_uuid() -> String {
-    use rand::RngCore;
+    use rand::Rng;
     let mut bytes = [0u8; 16];
-    rand::thread_rng().fill_bytes(&mut bytes);
+    rand::rng().fill_bytes(&mut bytes);
     bytes[6] = (bytes[6] & 0x0f) | 0x40;
     bytes[8] = (bytes[8] & 0x3f) | 0x80;
     format!(
@@ -291,7 +291,7 @@ mod tests {
     use super::*;
 
     fn test_keypair() -> SigningKey {
-        SigningKey::generate(&mut rand::thread_rng())
+        SigningKey::from_bytes(&rand::random())
     }
 
     #[test]

--- a/src/core/security.rs
+++ b/src/core/security.rs
@@ -49,7 +49,7 @@ impl SigningManager {
                 verifying_key,
             })
         } else {
-            let signing_key = SigningKey::generate(&mut rand::thread_rng());
+            let signing_key = SigningKey::from_bytes(&rand::random());
             let verifying_key = signing_key.verifying_key();
             if let Some(parent) = key_path.parent() {
                 std::fs::create_dir_all(parent)?;
@@ -136,8 +136,8 @@ impl EncryptionManager {
             s
         } else {
             let mut s = vec![0u8; 16];
-            use rand::RngCore;
-            rand::thread_rng().fill_bytes(&mut s);
+            use rand::Rng;
+            rand::rng().fill_bytes(&mut s);
             std::fs::write(&salt_path, &s)?;
             s
         };
@@ -157,8 +157,8 @@ impl EncryptionManager {
     /// Encrypt data. Returns `[nonce:12][ciphertext+tag]`.
     pub fn encrypt(&self, plaintext: &[u8]) -> Result<Vec<u8>> {
         let mut nonce_bytes = [0u8; 12];
-        use rand::RngCore;
-        rand::thread_rng().fill_bytes(&mut nonce_bytes);
+        use rand::Rng;
+        rand::rng().fill_bytes(&mut nonce_bytes);
         let nonce = Nonce::from_slice(&nonce_bytes);
 
         let ciphertext = self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2552,10 +2552,10 @@ mod meaning_tests {
             let original =
                 crate::core::entangled::EntangledHVec::new_deterministic(16384, probe_seed);
             let mut noisy_indices = original.indices().to_vec();
-            let mut rng = rand::thread_rng();
-            use rand::Rng;
+            let mut rng = rand::rng();
+            use rand::RngExt;
             for idx in noisy_indices.iter_mut().take(16) {
-                *idx = rng.gen_range(0..16384u32);
+                *idx = rng.random_range(0..16384u32);
             }
             noisy_indices.sort_unstable();
             noisy_indices.dedup();
@@ -2942,11 +2942,12 @@ mod ts_export_tests {
 
     #[test]
     fn export_ts_bindings() {
-        crate::RetrievalResult::export_all().unwrap();
-        crate::ConceptCandidate::export_all().unwrap();
-        crate::TextMetrics::export_all().unwrap();
-        crate::MemorizeBatchItem::export_all().unwrap();
-        crate::HmsError::export_all().unwrap();
+        let cfg = ts_rs::Config::default();
+        crate::RetrievalResult::export_all(&cfg).unwrap();
+        crate::ConceptCandidate::export_all(&cfg).unwrap();
+        crate::TextMetrics::export_all(&cfg).unwrap();
+        crate::MemorizeBatchItem::export_all(&cfg).unwrap();
+        crate::HmsError::export_all(&cfg).unwrap();
     }
 
     #[test]
@@ -2955,7 +2956,7 @@ mod ts_export_tests {
         let dir = std::path::Path::new("schemas");
         std::fs::create_dir_all(dir).unwrap();
 
-        let schemas: Vec<(&str, schemars::schema::RootSchema)> = vec![
+        let schemas: Vec<(&str, schemars::Schema)> = vec![
             ("RetrievalResult", schema_for!(crate::RetrievalResult)),
             ("ConceptCandidate", schema_for!(crate::ConceptCandidate)),
             ("TextMetrics", schema_for!(crate::TextMetrics)),


### PR DESCRIPTION
Combined landing for the 10 open Dependabot major-version PRs, which all touch `Cargo.toml` and conflict pairwise. Applies every bump on one branch and fixes the code for the new APIs. Supersedes and closes #12 #16 #18 #19 #20 #21 #22 #23 #24 #25.

## Bumps and code changes
| PR | Dep | From → To | Change |
|----|-----|-----------|--------|
| #12 | thiserror | 1.0 → 2.0 | none (named-field error attrs still valid) |
| #16 | lz4_flex | 0.11 → 0.13 | none (block API unchanged) |
| #18 | rand | 0.8 → 0.10 | `gen`→`random`, `gen_range`→`random_range`, `thread_rng`→`rng`, ergonomic methods moved to `RngExt`; `SigningKey::generate` → `from_bytes(&rand::random())` (rand_core 0.6 vs 0.10 mismatch) |
| #19 | napi-derive | 2.14 → 3.5 (→3.6) | macros source-compatible |
| #20 | criterion | 0.5 → 0.8 | `criterion::black_box` → `std::hint::black_box` |
| #21 | bincode | 1.3 → **2.0** | `serialize`/`deserialize` → `bincode::serde::encode_to_vec`/`decode_from_slice` + `config::standard()` |
| #22 | napi | 2.14 → 3.9 (→3.11) | `@napi-rs/cli` 2→3, napi config → `binaryName`/`targets`, build passes `--features node-api` |
| #23 | ts-rs | 10 → 12 | `TS::export_all(&ts_rs::Config)` |
| #24 | schemars | 0.8 → 1.2 | `schema::RootSchema` → `Schema`; regenerated `schemas/*.json` to JSON Schema 2020-12 |
| #25 | sha2 | 0.10 → 0.11 | none (Digest API unchanged) |

## bincode: 2.0, not 3.0
Dependabot's #21 target `bincode 3.0.0` is an intentionally broken placeholder release — its entire `lib.rs` is `compile_error!("https://xkcd.com/2347/")`. The real current major is 2.x, so this lands **bincode 2.0.1** (the encode/decode rewrite). RUSTSEC-2025-0141 still applies because bincode is unmaintained at every version; the `deny.toml` ignore is kept with an updated reason.

## Also
Fixed a latent `unnecessary_cast` clippy lint in `phase_resonator.rs` (a `usize as usize` in a test) that only surfaced once clippy could compile the test module under `--all-features`.

## Local CI-equivalent results (all green)
- `cargo fmt -- --check` — pass
- `cargo clippy --all-targets --all-features -- -D warnings` — 0 warnings
- `cargo test` — 266 passed, 0 failed
- `cargo bench --no-run --no-default-features` — ok
- `cargo deny check advisories bans licenses sources` — advisories ok, bans ok, licenses ok, sources ok
- `npm run build` (`napi build --release --features node-api`) — ok, `.node` produced