### PR TITLE
fix: resolve clippy::chunks_exact_to_as_chunks lint regression on main

### DIFF
--- a/src/core/engine/mod.rs
+++ b/src/core/engine/mod.rs
@@ -470,8 +470,10 @@ impl HmsCore {
             return (id, EntangledHVec::from_indices(vec![], 0));
         }
         let deltas: Vec<u32> = payload[deltas_start..deltas_end]
-            .chunks_exact(4)
-            .map(|c| u32::from_le_bytes(c.try_into().expect("chunks_exact(4)")))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|c| u32::from_le_bytes(*c))
             .collect();
         (id, EntangledHVec::from_deltas(&deltas, dimensions))
     }


### PR DESCRIPTION
## What changed
Rewrite the delta-decoding loop in `src/core/engine/mod.rs` from `.chunks_exact(4)` to `.as_chunks::<4>().0.iter()`.

## Why
CI's stable toolchain moved to rustc 1.98, which ships the new `clippy::chunks_exact_to_as_chunks` lint. `#![deny(clippy::all)]` in `src/lib.rs` turns that into a hard compile error, so every job on main (and every non-workflow Dependabot PR waiting behind it) has been red since the toolchain bump. The rewrite is clippy's own suggested fix; `slice::as_chunks` has been stable since Rust 1.88, and this crate's MSRV is 1.89 (`rust-version` in `Cargo.toml`, exercised by the `msrv` CI job), so no MSRV gap. This also drops the now-redundant `try_into().expect(...)` since `as_chunks` guarantees exact `[u8; 4]` arrays instead of runtime-checked slices.

## Validation
- cargo fmt -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo check --all-targets --all-features
- cargo test --all-features --verbose